### PR TITLE
Fix double memory free

### DIFF
--- a/files.c
+++ b/files.c
@@ -206,7 +206,6 @@ int add_file_record(unsigned int fid, char *uid, char act_allow, char *filename,
 
 	tmp->binprm = kmalloc(binprm_len+1, GFP_KERNEL);
 	if (tmp->binprm == NULL) {
-		kfree(tmp->filename);
 		err = -EOPNOTSUPP;
 		goto out;
 	}


### PR DESCRIPTION
`tmp->filename` will be freed again in `free_file_record()` after jump to `out:`, and cause a double memory free issue.