### PR TITLE
Kernel 6.14 update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "makefile.configureOnOpen": false
+}

--- a/NEW_HOOKS_ANALYSIS.md
+++ b/NEW_HOOKS_ANALYSIS.md
@@ -1,0 +1,158 @@
+# LSM Hook Comparison: HoneyBest vs Other Security Modules (Kernel 6.14)
+
+## Executive Summary
+
+**HoneyBest Status**: 49 hooks implemented (most comprehensive among compared modules)
+- YAMA: 4 hooks
+- LOADPIN: 3 hooks  
+- TOMOYO: 29 hooks
+- **HONEYBEST: 49 hooks** ✓
+
+## New Hooks Added Since Kernel 4.x
+
+### ✅ IMPLEMENTED in HoneyBest
+
+1. **kernel_read_file** ✓
+   - Status: IMPLEMENTED (wrapped in `#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,9,0)`)
+   - Location: `honeybest.c:3801`, registered at line 5047
+   - Used by: LOADPIN
+   - Purpose: Security check when kernel reads a file
+
+### ❌ NOT IMPLEMENTED in HoneyBest
+
+2. **kernel_load_data**
+   - Status: NOT IMPLEMENTED
+   - Used by: LOADPIN
+   - Purpose: Security check when kernel loads data (firmware, modules, etc.)
+   - Impact: Cannot track kernel data loading operations
+
+3. **bprm_creds_for_exec**
+   - Status: NOT IMPLEMENTED
+   - Used by: TOMOYO
+   - Purpose: Called before credentials are prepared for exec
+   - Impact: Missing early exec credential tracking
+
+4. **bprm_check_security**
+   - Status: NOT IMPLEMENTED
+   - Used by: TOMOYO
+   - Purpose: Security check for binary execution
+   - Impact: Missing binary execution security checks
+
+5. **bprm_creds_from_file**
+   - Status: NOT IMPLEMENTED
+   - Purpose: Credentials from file operations
+   - Impact: Limited credential tracking
+
+6. **file_truncate**
+   - Status: NOT IMPLEMENTED
+   - Used by: TOMOYO
+   - Purpose: Check permission to truncate a file
+   - Impact: Cannot track file truncation operations
+   - Note: HoneyBest has `file_mprotect`, `file_lock`, `file_fcntl` but not `file_truncate`
+
+7. **file_ioctl_compat**
+   - Status: NOT IMPLEMENTED
+   - Used by: TOMOYO
+   - Purpose: Compat ioctl security check (32-bit on 64-bit systems)
+   - Impact: Missing compat ioctl tracking
+   - Note: HoneyBest has `file_ioctl` but not `file_ioctl_compat`
+
+8. **path_chroot**
+   - Status: NOT IMPLEMENTED
+   - Used by: TOMOYO
+   - Purpose: Check permission to change root directory
+   - Impact: Cannot track chroot operations
+   - Note: HoneyBest has other path hooks but not `path_chroot`
+
+9. **fs_context_submount**
+   - Status: NOT IMPLEMENTED
+   - Purpose: Check submount operations (new mount API)
+   - Impact: Missing modern mount API support
+
+10. **fs_context_dup**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Duplicate fs_context (new mount API)
+    - Impact: Missing modern mount API support
+
+11. **fs_context_parse_param**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Parse mount parameters (new mount API)
+    - Impact: Missing modern mount API support
+
+12. **move_mount**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Check move mount operations
+    - Impact: Missing mount move tracking
+
+13. **dentry_create_files_as**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Create files with different credentials
+    - Impact: Limited credential-based file creation tracking
+
+14. **path_post_mknod**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Post-mknod security check
+    - Impact: Missing post-mknod operations
+    - Note: HoneyBest has `path_mknod` but not `path_post_mknod`
+
+15. **sb_delete**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Superblock deletion hook
+    - Impact: Missing superblock deletion tracking
+    - Note: HoneyBest has `sb_alloc_security`, `sb_free_security` but not `sb_delete`
+
+16. **sb_eat_lsm_opts**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Parse LSM mount options
+    - Impact: Missing mount option parsing
+
+17. **sb_mnt_opts_compat**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Check mount options compatibility
+    - Impact: Missing mount options compatibility checks
+
+18. **sb_free_mnt_opts**
+    - Status: NOT IMPLEMENTED
+    - Purpose: Free mount options
+    - Impact: Missing mount options cleanup
+
+## Recommendations
+
+### High Priority (Security Impact)
+1. **kernel_load_data** - Critical for tracking firmware/module loading
+2. **bprm_check_security** - Important for binary execution security
+3. **file_truncate** - Common file operation that should be tracked
+
+### Medium Priority (Feature Completeness)
+4. **bprm_creds_for_exec** - Early exec credential tracking
+5. **file_ioctl_compat** - 32-bit compatibility support
+6. **path_chroot** - Root directory change tracking
+
+### Low Priority (Modern API Support)
+7. **fs_context_*** hooks - New mount API support (kernel 5.x+)
+8. **move_mount** - Modern mount operations
+9. **sb_*** mount option hooks - Enhanced mount option handling
+
+## Current HoneyBest Strengths
+
+HoneyBest already implements:
+- ✅ Comprehensive path operations (10 hooks)
+- ✅ Comprehensive inode operations (15+ hooks)
+- ✅ Comprehensive file operations (10+ hooks)
+- ✅ Socket operations
+- ✅ IPC operations
+- ✅ Task/credential operations
+- ✅ Superblock operations (basic)
+- ✅ Ptrace operations
+- ✅ Kernel module operations
+- ✅ kernel_read_file (for kernel 4.9+)
+
+## Conclusion
+
+HoneyBest has the most comprehensive hook coverage (49 hooks) among the compared modules. However, it's missing approximately 17 newer hooks that were added since kernel 4.x, particularly:
+- `kernel_load_data` (used by LOADPIN)
+- `bprm_check_security` and `bprm_creds_for_exec` (used by TOMOYO)
+- `file_truncate` and `file_ioctl_compat` (used by TOMOYO)
+- Modern mount API hooks (`fs_context_*`)
+
+These missing hooks don't prevent compilation or basic functionality, but implementing them would provide more complete security coverage.

--- a/audit.c
+++ b/audit.c
@@ -1,7 +1,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -67,7 +66,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include <linux/version.h>
 #include <linux/module.h>
@@ -88,7 +87,7 @@ int honeybest_audit_report(char *report)
 	audit_log_format(ab, " comm=");
 	audit_log_untrustedstring(ab, "honeybest");
 	audit_log_format(ab, " cause=");
-       	audit_log_string(ab, report);
+       	audit_log_untrustedstring(ab, report);
 
 	audit_log_end(ab);
 

--- a/create_branch_and_push.sh
+++ b/create_branch_and_push.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# Script to create a new branch, sync files, and push to GitHub
+set -e
+
+KERNEL_SOURCE_DIR="/home/moxa/Work/linux-6.14/security/honeybest"
+HONEYBEST_REPO_DIR="/home/moxa/Work/honeybest"
+BRANCH_NAME="kernel-6.14-update"
+
+echo "=== Creating branch and pushing to GitHub ==="
+echo ""
+
+# Navigate to the HoneyBest repository
+cd "$HONEYBEST_REPO_DIR" || { echo "Error: Could not change to HoneyBest repository directory."; exit 1; }
+
+# Check if it's a git repository
+if [ ! -d .git ]; then
+    echo "Error: Not a git repository. Please initialize git first."
+    exit 1
+fi
+
+# Check current branch
+CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+echo "Current branch: $CURRENT_BRANCH"
+
+# Create and checkout new branch
+echo ""
+echo "Step 1: Creating new branch '$BRANCH_NAME'..."
+if git show-ref --verify --quiet refs/heads/"$BRANCH_NAME"; then
+    echo "Branch '$BRANCH_NAME' already exists. Checking it out..."
+    git checkout "$BRANCH_NAME"
+else
+    git checkout -b "$BRANCH_NAME" 2>&1 || {
+        echo "Failed to create branch. Trying alternative method..."
+        git branch "$BRANCH_NAME" 2>&1
+        git checkout "$BRANCH_NAME" 2>&1
+    }
+fi
+echo "✓ Branch '$BRANCH_NAME' is now active"
+
+# Copy updated source files
+echo ""
+echo "Step 2: Copying updated source files from kernel tree..."
+cp "$KERNEL_SOURCE_DIR"/*.c . 2>/dev/null || echo "Warning: Some .c files may not have been copied"
+cp "$KERNEL_SOURCE_DIR"/*.h . 2>/dev/null || echo "Warning: Some .h files may not have been copied"
+cp "$KERNEL_SOURCE_DIR"/Makefile . 2>/dev/null || echo "Warning: Makefile may not have been copied"
+cp "$KERNEL_SOURCE_DIR"/Kconfig . 2>/dev/null || echo "Warning: Kconfig may not have been copied"
+echo "✓ Source files copied"
+
+# Show status
+echo ""
+echo "Step 3: Checking git status..."
+git status --short | head -20
+
+# Add all changes
+echo ""
+echo "Step 4: Staging all changes..."
+git add -A
+echo "✓ Files staged"
+
+# Show what will be committed
+echo ""
+echo "Files to be committed:"
+git status --short
+
+# Commit changes
+echo ""
+echo "Step 5: Committing changes..."
+COMMIT_MESSAGE="Update for kernel 6.14 compatibility
+
+- Updated all LSM hook signatures for kernel 6.14
+- Fixed compilation errors (mmap_lock, proc_ops, sysctl API changes)
+- Updated CONFIG_SECURITY_HONEYBEST_PROD implementation
+- Fixed all *.c and *.h files initialization
+- Fixed patch file Makefile hunk (added missing + prefix)
+- Updated patches for kernel 6.14
+- Added comprehensive hook analysis documentation (NEW_HOOKS_ANALYSIS.md)
+- Verified KERNEL_VERSION compatibility
+- Confirmed CONFIG_SECURITY_PATH compilation
+- All source files updated and tested"
+
+if git diff --cached --quiet; then
+    echo "No changes to commit. Files may already be up to date."
+else
+    git commit -m "$COMMIT_MESSAGE" || {
+        echo "Commit failed or was cancelled."
+        exit 1
+    }
+    echo "✓ Changes committed"
+fi
+
+# Check remote
+echo ""
+echo "Step 6: Checking remote configuration..."
+if ! git remote | grep -q origin; then
+    echo "⚠️  No 'origin' remote found. Please add remote:"
+    echo "   git remote add origin <your-github-repo-url>"
+    exit 1
+fi
+
+REMOTE_URL=$(git remote get-url origin 2>/dev/null || echo "not set")
+echo "Remote URL: $REMOTE_URL"
+
+# Push to GitHub
+echo ""
+echo "Step 7: Pushing branch '$BRANCH_NAME' to GitHub..."
+git push -u origin "$BRANCH_NAME" 2>&1 || {
+    echo "⚠️  Push failed. Error details above."
+    echo ""
+    echo "Troubleshooting:"
+    echo "1. Check your GitHub authentication"
+    echo "2. Verify remote URL: $REMOTE_URL"
+    echo "3. Ensure you have push permissions"
+    exit 1
+}
+
+echo ""
+echo "=== Success! ==="
+echo "Branch '$BRANCH_NAME' has been pushed to GitHub."
+echo ""
+echo "Next steps:"
+echo "1. Go to your GitHub repository"
+echo "2. You should see a prompt to create a Pull Request for '$BRANCH_NAME'"
+echo "3. Click 'Compare & pull request' to merge via web interface"
+echo ""
+echo "Or visit: https://github.com/<your-username>/<repo-name>/compare/$BRANCH_NAME"

--- a/creds.c
+++ b/creds.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include <linux/version.h>
 #include "creds.h"
@@ -266,7 +265,6 @@ int lookup_binprm_digest(struct file *file, char *digest)
 	}
 
        	desc->tfm = tfm;
-       	desc->flags = crypto_shash_get_flags(tfm);
        	err = crypto_shash_init(desc);
 
 	if (err) {

--- a/files.c
+++ b/files.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "files.h"
 #include "regex.h"

--- a/inode.c
+++ b/inode.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "inode.h"
 #include "regex.h"

--- a/ipc.c
+++ b/ipc.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "ipc.h"
 #include "regex.h"

--- a/kmod.c
+++ b/kmod.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "kmod.h"
 #include "notify.h"

--- a/notify.c
+++ b/notify.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "notify.h"
 #include "creds.h"

--- a/patches/honeybest-kernel-option.patch
+++ b/patches/honeybest-kernel-option.patch
@@ -32,7 +32,7 @@ index 000000000000..111111111111 100644
 @@ -20,6 +20,7 @@ obj-$(CONFIG_SECURITY_TOMOYO)		+= tomoyo/
  obj-$(CONFIG_SECURITY_APPARMOR)		+= apparmor/
  obj-$(CONFIG_SECURITY_YAMA)		+= yama/
- obj-$(CONFIG_SECURITY_HONEYBEST)	+= honeybest/
++obj-$(CONFIG_SECURITY_HONEYBEST)	+= honeybest/
  obj-$(CONFIG_SECURITY_LOADPIN)		+= loadpin/
  obj-$(CONFIG_SECURITY_SAFESETID)       += safesetid/
  obj-$(CONFIG_SECURITY_LOCKDOWN_LSM)	+= lockdown/

--- a/patches/honeybest-kernel-option.patch
+++ b/patches/honeybest-kernel-option.patch
@@ -1,10 +1,10 @@
 diff --git a/include/linux/lsm_hooks.h b/include/linux/lsm_hooks.h
-index ec3a6bab29de..2f181c766124 100644
+index 000000000000..111111111111 100644
 --- a/include/linux/lsm_hooks.h
 +++ b/include/linux/lsm_hooks.h
-@@ -1887,4 +1887,10 @@ extern void __init yama_add_hooks(void);
- static inline void __init yama_add_hooks(void) { }
- #endif
+@@ -192,4 +192,10 @@ static inline struct xattr *lsm_get_xattr_slot(struct xattr *xattrs,
+ 	return &xattrs[(*xattr_count)++];
+ }
  
 +#ifdef CONFIG_SECURITY_HONEYBEST
 +extern void __init honeybest_add_hooks(void);
@@ -14,47 +14,48 @@ index ec3a6bab29de..2f181c766124 100644
 +
  #endif /* ! __LINUX_LSM_HOOKS_H */
 diff --git a/security/Kconfig b/security/Kconfig
-index a3ebb6ee5bd5..ab9d161fc97b 100644
+index 000000000000..111111111111 100644
 --- a/security/Kconfig
 +++ b/security/Kconfig
-@@ -133,6 +133,8 @@ source security/smack/Kconfig
- source security/tomoyo/Kconfig
- source security/apparmor/Kconfig
- source security/yama/Kconfig
-+source security/honeybest/Kconfig
-+
- 
- source security/integrity/Kconfig
- 
+@@ -225,6 +225,7 @@ source "security/tomoyo/Kconfig"
+ source "security/apparmor/Kconfig"
+ source "security/loadpin/Kconfig"
+ source "security/yama/Kconfig"
++source "security/honeybest/Kconfig"
+ source "security/safesetid/Kconfig"
+ source "security/lockdown/Kconfig"
+ source "security/landlock/Kconfig"
 diff --git a/security/Makefile b/security/Makefile
-index c9bfbc84ff50..496696b318a1 100644
+index 000000000000..111111111111 100644
 --- a/security/Makefile
 +++ b/security/Makefile
-@@ -8,6 +8,7 @@ subdir-$(CONFIG_SECURITY_SMACK)		+= smack
- subdir-$(CONFIG_SECURITY_TOMOYO)        += tomoyo
- subdir-$(CONFIG_SECURITY_APPARMOR)	+= apparmor
- subdir-$(CONFIG_SECURITY_YAMA)		+= yama
-+subdir-$(CONFIG_SECURITY_HONEYBEST)	+= honeybest
- 
- # always enable default capabilities
- obj-y					+= commoncap.o
-@@ -23,6 +24,7 @@ obj-$(CONFIG_SECURITY_TOMOYO)		+= tomoyo/
+@@ -20,6 +20,7 @@ obj-$(CONFIG_SECURITY_TOMOYO)		+= tomoyo/
  obj-$(CONFIG_SECURITY_APPARMOR)		+= apparmor/
  obj-$(CONFIG_SECURITY_YAMA)		+= yama/
- obj-$(CONFIG_CGROUP_DEVICE)		+= device_cgroup.o
-+obj-$(CONFIG_SECURITY_HONEYBEST)	+= honeybest/
- 
- # Object integrity file lists
- subdir-$(CONFIG_INTEGRITY)		+= integrity
+ obj-$(CONFIG_SECURITY_HONEYBEST)	+= honeybest/
+ obj-$(CONFIG_SECURITY_LOADPIN)		+= loadpin/
+ obj-$(CONFIG_SECURITY_SAFESETID)       += safesetid/
+ obj-$(CONFIG_SECURITY_LOCKDOWN_LSM)	+= lockdown/
 diff --git a/security/security.c b/security/security.c
-index 0dde287db5c5..d0801450d592 100644
+index 000000000000..111111111111 100644
 --- a/security/security.c
 +++ b/security/security.c
-@@ -60,6 +60,7 @@ int __init security_init(void)
- 	 */
- 	capability_add_hooks();
- 	yama_add_hooks();
-+	honeybest_add_hooks();
+@@ -20,6 +20,9 @@
+ #include <linux/kernel_read_file.h>
+ #include <linux/lsm_hooks.h>
++#ifdef CONFIG_SECURITY_HONEYBEST
++extern void __init honeybest_add_hooks(void);
++#endif
+ #include <linux/mman.h>
+ #include <linux/mount.h>
+ #include <linux/personality.h>
+@@ -543,6 +546,9 @@ int __init security_init(void)
+ 	/* Load LSMs in specified order. */
+ 	ordered_lsm_init();
  
- 	/*
- 	 * Load all the remaining security modules.
++#ifdef CONFIG_SECURITY_HONEYBEST
++	honeybest_add_hooks();
++#endif
++
+ 	return 0;
+ }

--- a/path.c
+++ b/path.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -82,7 +81,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include <linux/path.h>
 #include "path.h"

--- a/ptrace.c
+++ b/ptrace.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include <linux/version.h>
 #include "ptrace.h"

--- a/regex.c
+++ b/regex.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "regex.h"
 #include "honeybest.h"

--- a/sb.c
+++ b/sb.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "sb.h"
 #include "notify.h"

--- a/socket.c
+++ b/socket.c
@@ -18,7 +18,6 @@
 #include <linux/version.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -84,7 +83,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "socket.h"
 #include "notify.h"

--- a/sync_and_push.sh
+++ b/sync_and_push.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Script to sync updated files from kernel tree and push to GitHub
+set -e
+
+KERNEL_SOURCE_DIR="/home/moxa/Work/linux-6.14/security/honeybest"
+HONEYBEST_REPO_DIR="/home/moxa/Work/honeybest"
+
+echo "=== HoneyBest GitHub Sync Script ==="
+echo ""
+
+# Navigate to the HoneyBest repository
+cd "$HONEYBEST_REPO_DIR" || { echo "Error: Could not change to HoneyBest repository directory."; exit 1; }
+
+# Check if it's a git repository
+if [ ! -d .git ]; then
+    echo "Error: Not a git repository. Please initialize git first."
+    exit 1
+fi
+
+# Copy updated source files
+echo "Step 1: Copying updated source files from kernel tree..."
+cp "$KERNEL_SOURCE_DIR"/*.c . 2>/dev/null || true
+cp "$KERNEL_SOURCE_DIR"/*.h . 2>/dev/null || true
+cp "$KERNEL_SOURCE_DIR"/Makefile . 2>/dev/null || true
+cp "$KERNEL_SOURCE_DIR"/Kconfig . 2>/dev/null || true
+echo "✓ Source files copied"
+
+# Show status
+echo ""
+echo "Step 2: Checking git status..."
+git status --short | head -20
+
+# Add all changes
+echo ""
+echo "Step 3: Staging all changes..."
+git add -A
+echo "✓ Files staged"
+
+# Commit changes
+echo ""
+echo "Step 4: Committing changes..."
+COMMIT_MESSAGE="Update for kernel 6.14 compatibility
+
+- Updated all LSM hook signatures for kernel 6.14
+- Fixed compilation errors (mmap_lock, proc_ops, sysctl API changes)
+- Updated CONFIG_SECURITY_HONEYBEST_PROD implementation
+- Fixed all *.c and *.h files initialization
+- Fixed patch file Makefile hunk (added missing + prefix)
+- Updated patches for kernel 6.14
+- Added comprehensive hook analysis documentation (NEW_HOOKS_ANALYSIS.md)
+- Verified KERNEL_VERSION compatibility
+- Confirmed CONFIG_SECURITY_PATH compilation
+- All source files updated and tested"
+
+git commit -m "$COMMIT_MESSAGE" || echo "Note: No changes to commit or commit failed"
+echo "✓ Changes committed"
+
+# Determine branch
+BRANCH=$(git branch --show-current 2>/dev/null || git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+echo ""
+echo "Step 5: Pushing to GitHub (branch: $BRANCH)..."
+
+# Check remote
+if git remote | grep -q origin; then
+    echo "Remote 'origin' found"
+    git push origin "$BRANCH" 2>&1 || {
+        echo "Push failed. Trying alternative branches..."
+        git push origin main 2>&1 || git push origin master 2>&1 || {
+            echo "⚠️  Push failed. Please check:"
+            echo "   1. Remote URL: $(git remote get-url origin 2>/dev/null || echo 'not set')"
+            echo "   2. Branch name: $BRANCH"
+            echo "   3. Authentication credentials"
+            exit 1
+        }
+    }
+    echo "✓ Successfully pushed to GitHub"
+else
+    echo "⚠️  No 'origin' remote found. Please add remote:"
+    echo "   git remote add origin <your-github-repo-url>"
+    exit 1
+fi
+
+echo ""
+echo "=== Sync Complete ==="

--- a/tasks.c
+++ b/tasks.c
@@ -17,7 +17,6 @@
 #include <linux/init.h>
 #include <linux/kd.h>
 #include <linux/kernel.h>
-#include <linux/tracehook.h>
 #include <linux/errno.h>
 #include <linux/sched.h>
 #include <linux/lsm_hooks.h>
@@ -83,7 +82,7 @@
 #include <linux/string_helpers.h>
 #include <linux/list.h>
 #include <crypto/hash.h>
-#include <crypto/sha.h>
+#include <crypto/sha1.h>
 #include <crypto/algapi.h>
 #include "tasks.h"
 #include "notify.h"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns HoneyBest with Linux 6.14 kernel interfaces and registration flow.
> 
> - Update numerous LSM hook prototypes and types (e.g., `task_alloc`, `file_open`, inode/xattr/idmap variants, socket/IPSec, Binder, audit) to 6.14 signatures
> - Replace deprecated APIs: `mmap_sem` -> `mmap_read_lock/unlock`, `file_operations` -> `proc_ops`, `register_sysctl_paths` -> `register_sysctl`, `MS_NOUSER` -> `SB_NOUSER`
> - Switch crypto include `crypto/sha.h` to `crypto/sha1.h`; drop `tracehook` includes
> - Adjust path initializations to designated form and various const-correctness updates
> - Add `lsm_id` and call `security_add_hooks(..., &honeybest_lsmid)`; wire `honeybest_add_hooks()` into `security.c`, plus Kconfig/Makefile entries via patch in `patches/`
> - Minor behavior tweaks: use `audit_log_untrustedstring` in `audit.c`
> - Add docs (`NEW_HOOKS_ANALYSIS.md`) summarizing implemented/missing hooks and helper scripts (`create_branch_and_push.sh`, `sync_and_push.sh`); add `.vscode` setting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1aeed0800a6e3c20b433339794fe88a01df8c8bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->